### PR TITLE
Misc shapes and fixes

### DIFF
--- a/src/constants/gradient-fill-type.ts
+++ b/src/constants/gradient-fill-type.ts
@@ -1,7 +1,7 @@
 export enum GradientFillType {
-  NONE = 1,
-  LINEAR = 2,
-  RADIAL = 3,
+  NONE = 0,
+  LINEAR = 1,
+  RADIAL = 2,
   ANGULAR = 4,
   REFLECTED = 5,
   DIAMOND = 6,

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -10,3 +10,4 @@ export * from './mask-mode';
 export * from './property-type';
 export * from './shape-type';
 export * from './trim-mode';
+export * from './repeater-composite';

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -9,3 +9,4 @@ export * from './line-join-type';
 export * from './mask-mode';
 export * from './property-type';
 export * from './shape-type';
+export * from './trim-mode';

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -11,3 +11,4 @@ export * from './property-type';
 export * from './shape-type';
 export * from './trim-mode';
 export * from './repeater-composite';
+export * from './star-type';

--- a/src/constants/repeater-composite.ts
+++ b/src/constants/repeater-composite.ts
@@ -1,0 +1,4 @@
+export enum RepeaterComposite {
+  ABOVE = 1,
+  BELOW = 2,
+}

--- a/src/constants/star-type.ts
+++ b/src/constants/star-type.ts
@@ -1,0 +1,4 @@
+export enum StarType {
+  STAR = 1,
+  POLYGON = 2,
+}

--- a/src/constants/trim-mode.ts
+++ b/src/constants/trim-mode.ts
@@ -1,0 +1,4 @@
+export enum TrimMode {
+  SIMULTANEOUSLY = 1,
+  INDIVIDUALLY = 2,
+}

--- a/src/properties/gradient.ts
+++ b/src/properties/gradient.ts
@@ -16,15 +16,15 @@ export class GradientStop {
   }
 
   get red(): number {
-    return this.color[0]!;
+    return this.color[0];
   }
 
   get green(): number {
-    return this.color[1]!;
+    return this.color[1];
   }
 
   get blue(): number {
-    return this.color[2]!;
+    return this.color[2];
   }
 
   get alpha(): number | undefined {
@@ -83,7 +83,7 @@ class GradientColorsProperty extends Property {
     if (hasAlpha) {
       for (const color of stops) {
         result.push(color.offset);
-        result.push(color.hasAlpha ? color.alpha! : 1);
+        result.push(color.alpha !== undefined ? color.alpha : 1);
       }
     }
 

--- a/src/properties/gradient.ts
+++ b/src/properties/gradient.ts
@@ -1,0 +1,130 @@
+import { PropertyType } from '../constants';
+import { KeyFrame } from '../timeline/key-frame';
+import { Property } from './property';
+
+export class GradientStop {
+  public offset: number;
+  public color: number[];
+
+  constructor(offset = 0, color: number[] = []) {
+    this.offset = offset;
+    this.color = color;
+  }
+
+  get hasAlpha(): boolean {
+    return this.color.length > 3;
+  }
+
+  get red(): number {
+    return this.color[0]!;
+  }
+
+  get green(): number {
+    return this.color[1]!;
+  }
+
+  get blue(): number {
+    return this.color[2]!;
+  }
+
+  get alpha(): number | undefined {
+    return this.color[3];
+  }
+}
+
+class GradientColorsProperty extends Property {
+  public colorCount = 0;
+
+  private keyframeValue(index: number): number[] {
+    if (index >= this.values.length) return [];
+    return this.values[index].value as number[];
+  }
+
+  public keyframeHasAlpha(index: number): boolean {
+    return this.keyframeValue(index).length == this.colorCount * 6;
+  }
+
+  public keframeStops(index: number): GradientStop[] {
+    const values = this.keyframeValue(index);
+    const stops: GradientStop[] = [];
+    const hasAlpha = this.keyframeHasAlpha(index);
+    for (let i = 0; i < this.colorCount; i++) {
+      const color = values.slice(i, 3);
+      if (hasAlpha) color.push(values[this.colorCount * 4 + i * 2]);
+      stops.push(new GradientStop(values[i * 4], color));
+    }
+    return stops;
+  }
+
+  public setKeyframeStops(index: number, stops: GradientStop[]) {
+    if (index >= this.values.length) return;
+    if (stops.length > this.colorCount) this.colorCount = stops.length;
+    this.values[index].value = this.stopsToArray(stops);
+  }
+
+  public addKeyframe(frame: number, stops: GradientStop[]) {
+    const keyframe: KeyFrame = new KeyFrame(frame, this.stopsToArray(stops));
+    if (stops.length > this.colorCount) this.colorCount = stops.length;
+    this.values.push(keyframe);
+    return keyframe;
+  }
+
+  private stopsToArray(stops: GradientStop[]): number[] {
+    let hasAlpha = false;
+    const result: number[] = [];
+    for (const color of stops) {
+      result.push(color.offset);
+      result.push(color.red);
+      result.push(color.green);
+      result.push(color.blue);
+      if (color.hasAlpha) hasAlpha = true;
+    }
+
+    if (hasAlpha) {
+      for (const color of stops) {
+        result.push(color.offset);
+        result.push(color.hasAlpha ? color.alpha! : 1);
+      }
+    }
+
+    return result;
+  }
+}
+
+export class Gradient {
+  public gradientColors: GradientColorsProperty = new GradientColorsProperty(this, PropertyType.COLOR);
+
+  public get colorCount(): number {
+    return this.gradientColors.colorCount;
+  }
+
+  public set colorCount(count: number) {
+    this.gradientColors.colorCount = count;
+  }
+
+  /**
+   * Convert the class instance to Lottie JSON object.
+   *
+   * Called by Javascript when serializing object with JSON.stringify()
+   *
+   * @returns       JSON object
+   */
+  public toJSON(): Record<string, any> {
+    return {
+      p: this.colorCount,
+      k: this.gradientColors,
+    };
+  }
+
+  /**
+   * Convert the Lottie JSON object to class instance.
+   *
+   * @param json    JSON object
+   * @returns       Gradient instance
+   */
+  public fromJSON(json: Record<string, any>): Gradient {
+    this.gradientColors.fromJSON(json.k);
+    this.colorCount = json.p;
+    return this;
+  }
+}

--- a/src/properties/index.ts
+++ b/src/properties/index.ts
@@ -1,1 +1,2 @@
 export * from './property';
+export * from './gradient';

--- a/src/properties/property.ts
+++ b/src/properties/property.ts
@@ -37,10 +37,12 @@ export class Property {
    * @param parent      Parent instance the property belongs to.
    * @param type        Property type.
    */
-  constructor(parent: any, type: PropertyType) {
+  constructor(parent: any, type: PropertyType, values: Array<KeyFrame> = []) {
     this._parent = parent;
 
     this.type = type;
+    this.values = values;
+    this.isAnimated = values.length > 1;
 
     useRegistry().set(this, parent);
   }

--- a/src/shapes/gradient-stroke-shape.ts
+++ b/src/shapes/gradient-stroke-shape.ts
@@ -1,15 +1,15 @@
-import { BlendMode, FillRuleType, GradientFillType, PropertyType, ShapeType } from '../constants';
+import { BlendMode, GradientFillType, LineCapType, LineJoinType, PropertyType, ShapeType } from '../constants';
 import { Gradient, Property } from '../properties';
 import { Shape } from './shape';
 
 /**
- * Gradient fill shape type.
+ * Gradient stroke shape type.
  */
-export class GradientFillShape extends Shape {
+export class GradientStrokeShape extends Shape {
   /**
-   * Gradient shape type: gf
+   * Gradient shape type: gs
    */
-  public readonly type = ShapeType.GRADIENT_FILL;
+  public readonly type = ShapeType.GRADIENT_STROKE;
 
   public blendMode: BlendMode = BlendMode.NORMAL;
 
@@ -27,7 +27,28 @@ export class GradientFillShape extends Shape {
 
   public startPoint: Property = new Property(this, PropertyType.POSITION);
 
-  public fillRule: FillRuleType = FillRuleType.EVEN_ODD;
+  /**
+   * Line cap.
+   *
+   * Mapped field: lc
+   */
+  public lineCapType: LineCapType = LineCapType.ROUND;
+
+  /**
+   * Line join.
+   *
+   * Mapped field: lj
+   */
+  public lineJoinType: LineJoinType = LineJoinType.ROUND;
+
+  /**
+   * Miter limit.
+   *
+   * Mapped field: ml
+   */
+  public miterLimit!: number;
+
+  public width: Property = new Property(this, PropertyType.STROKE_WIDTH);
 
   /**
    * Convert the Lottie JSON object to class instance.
@@ -35,7 +56,7 @@ export class GradientFillShape extends Shape {
    * @param json    JSON object
    * @returns       GradientFillShape instance
    */
-  public fromJSON(json: Record<string, any>): GradientFillShape {
+  public fromJSON(json: Record<string, any>): GradientStrokeShape {
     // Base shape
     this.classNames = json.cl;
     this.id = json.ln;
@@ -45,17 +66,24 @@ export class GradientFillShape extends Shape {
 
     // This shape
     this.blendMode = json.bm;
+    this.opacity.fromJSON(json.o);
+
+    // Gradient
     this.endPoint.fromJSON(json.e);
     this.gradientColors.fromJSON(json.g);
     this.gradientType = json.t;
-    this.opacity.fromJSON(json.o);
     this.startPoint.fromJSON(json.s);
-    this.fillRule = json.r;
 
     if (this.gradientType === GradientFillType.LINEAR) {
       this.highlightAngle.fromJSON(json.a);
       this.highlightLength.fromJSON(json.h);
     }
+
+    // Stroke
+    this.lineCapType = json.lc in LineCapType ? json.lc : LineCapType.ROUND;
+    this.lineJoinType = json.lj in LineJoinType ? json.lj : LineJoinType.ROUND;
+    this.miterLimit = json.ml;
+    this.width.fromJSON(json.w);
 
     return this;
   }
@@ -80,14 +108,21 @@ export class GradientFillShape extends Shape {
 
       // This shape
       bm: this.blendMode,
+      o: this.opacity,
+
+      // Gradient
       e: this.endPoint,
       g: this.gradientColors,
       t: this.gradientType,
       a: this.highlightAngle,
       h: this.highlightLength,
-      o: this.opacity,
-      r: this.fillRule,
       s: this.startPoint,
+
+      // Stroke
+      lc: this.lineCapType,
+      lj: this.lineJoinType,
+      ml: this.miterLimit,
+      w: this.width,
     };
   }
 }

--- a/src/shapes/index.ts
+++ b/src/shapes/index.ts
@@ -8,3 +8,4 @@ export * from './shape';
 export * from './stroke-shape';
 export * from './trim-shape';
 export * from './gradient-stroke-shape';
+export * from './repeater-shape';

--- a/src/shapes/index.ts
+++ b/src/shapes/index.ts
@@ -7,3 +7,4 @@ export * from './rectangle-shape';
 export * from './shape';
 export * from './stroke-shape';
 export * from './trim-shape';
+export * from './gradient-stroke-shape';

--- a/src/shapes/index.ts
+++ b/src/shapes/index.ts
@@ -10,3 +10,4 @@ export * from './trim-shape';
 export * from './gradient-stroke-shape';
 export * from './repeater-shape';
 export * from './star-shape';
+export * from './rounded-corners-shape';

--- a/src/shapes/index.ts
+++ b/src/shapes/index.ts
@@ -9,3 +9,4 @@ export * from './stroke-shape';
 export * from './trim-shape';
 export * from './gradient-stroke-shape';
 export * from './repeater-shape';
+export * from './star-shape';

--- a/src/shapes/repeater-shape.ts
+++ b/src/shapes/repeater-shape.ts
@@ -1,0 +1,110 @@
+import { PropertyType, ShapeType, RepeaterComposite } from '../constants';
+import { Property } from '../properties';
+import { Shape } from './shape';
+
+/**
+ * Repeater shape type.
+ */
+export class RepeaterShape extends Shape {
+  /**
+   * Repeater shape type: rp
+   */
+  public readonly type = ShapeType.REPEATER;
+
+  public anchor: Property = new Property(this, PropertyType.ANCHOR);
+
+  public startOpacity: Property = new Property(this, PropertyType.OPACITY);
+
+  public endOpacity: Property = new Property(this, PropertyType.OPACITY);
+
+  public position: Property = new Property(this, PropertyType.POSITION);
+
+  public rotation: Property = new Property(this, PropertyType.ROTATION);
+
+  public scale: Property = new Property(this, PropertyType.SCALE);
+
+  public shapes: Shape[] = [];
+
+  public skew: Property = new Property(this, PropertyType.SKEW);
+
+  public skewAxis: Property = new Property(this, PropertyType.SKEW_AXIS);
+
+  public copies: Property = new Property(this, PropertyType.NUMBER);
+
+  public offset: Property = new Property(this, PropertyType.NUMBER);
+
+  public composition: RepeaterComposite = RepeaterComposite.ABOVE;
+
+  /**
+   * Convert the Lottie JSON object to class instance.
+   *
+   * @param json    JSON object
+   * @returns       GroupShape instance
+   */
+  public fromJSON(json: Record<string, any>): RepeaterShape {
+    // Base shape
+    this.classNames = json.cl;
+    this.id = json.ln;
+    this.isHidden = json.hd;
+    this.matchName = json.mn;
+    this.name = json.nm;
+
+    // This shape
+    this.copies.fromJSON(json.c);
+    this.composition = json.m;
+    this.offset.fromJSON(json.o);
+
+    this.anchor.fromJSON(json.tr.a);
+    this.startOpacity.fromJSON(json.tr.so);
+    this.endOpacity.fromJSON(json.tr.eo);
+    this.position.fromJSON(json.tr.p);
+    this.rotation.fromJSON(json.tr.r);
+    this.scale.fromJSON(json.tr.s);
+
+    if (json.tr.sk) {
+      this.skew.fromJSON(json.tr.sk);
+    }
+
+    if (json.tr.sa) {
+      this.skewAxis.fromJSON(json.tr.sa);
+    }
+
+    return this;
+  }
+
+  /**
+   * Convert the class instance to Lottie JSON object.
+   *
+   * Called by Javascript when serializing object with JSON.stringify()
+   *
+   * @returns       JSON object
+   */
+  public toJSON(): Record<string, any> {
+
+    return {
+      ty: this.type,
+
+      // Base shape
+      cl: this.classNames,
+      hd: this.isHidden,
+      ln: this.id,
+      mn: this.matchName,
+      nm: this.name,
+
+      // This shape
+      m: this.composition,
+      c: this.copies,
+      o: this.offset,
+      tr: {
+        a: this.anchor,
+        so: this.startOpacity,
+        eo: this.endOpacity,
+        p: this.position,
+        r: this.rotation,
+        s: this.scale,
+        sk: this.skew,
+        sa: this.skewAxis,
+      }
+    };
+  }
+}

--- a/src/shapes/repeater-shape.ts
+++ b/src/shapes/repeater-shape.ts
@@ -1,4 +1,4 @@
-import { PropertyType, ShapeType, RepeaterComposite } from '../constants';
+import { PropertyType, RepeaterComposite, ShapeType } from '../constants';
 import { Property } from '../properties';
 import { Shape } from './shape';
 
@@ -80,7 +80,6 @@ export class RepeaterShape extends Shape {
    * @returns       JSON object
    */
   public toJSON(): Record<string, any> {
-
     return {
       ty: this.type,
 
@@ -104,7 +103,7 @@ export class RepeaterShape extends Shape {
         s: this.scale,
         sk: this.skew,
         sa: this.skewAxis,
-      }
+      },
     };
   }
 }

--- a/src/shapes/rounded-corners-shape.ts
+++ b/src/shapes/rounded-corners-shape.ts
@@ -1,0 +1,59 @@
+import { PropertyType, ShapeType } from '../constants';
+import { Property } from '../properties';
+import { Shape } from './shape';
+
+/**
+ * Rounded Corners shape type.
+ */
+export class RoundedCornersShape extends Shape {
+  /**
+   * RoundedCorners shape type: rp
+   */
+  public readonly type = ShapeType.ROUNDED_CORNERS;
+
+  public roundness: Property = new Property(this, PropertyType.NUMBER);
+
+  /**
+   * Convert the Lottie JSON object to class instance.
+   *
+   * @param json    JSON object
+   * @returns       GroupShape instance
+   */
+  public fromJSON(json: Record<string, any>): RoundedCornersShape {
+    // Base shape
+    this.classNames = json.cl;
+    this.id = json.ln;
+    this.isHidden = json.hd;
+    this.matchName = json.mn;
+    this.name = json.nm;
+
+    // This shape
+    this.roundness.fromJSON(json.r);
+
+    return this;
+  }
+
+  /**
+   * Convert the class instance to Lottie JSON object.
+   *
+   * Called by Javascript when serializing object with JSON.stringify()
+   *
+   * @returns       JSON object
+   */
+  public toJSON(): Record<string, any> {
+
+    return {
+      ty: this.type,
+
+      // Base shape
+      cl: this.classNames,
+      hd: this.isHidden,
+      ln: this.id,
+      mn: this.matchName,
+      nm: this.name,
+
+      // This shape
+      r: this.roundness,
+    };
+  }
+}

--- a/src/shapes/rounded-corners-shape.ts
+++ b/src/shapes/rounded-corners-shape.ts
@@ -41,7 +41,6 @@ export class RoundedCornersShape extends Shape {
    * @returns       JSON object
    */
   public toJSON(): Record<string, any> {
-
     return {
       ty: this.type,
 

--- a/src/shapes/star-shape.ts
+++ b/src/shapes/star-shape.ts
@@ -1,0 +1,86 @@
+import { PropertyType, ShapeType, StarType } from '../constants';
+import { Property } from '../properties';
+import { Shape } from './shape';
+
+/**
+ * Star shape type.
+ */
+export class StarShape extends Shape {
+  /**
+   * Shape type
+   */
+  public readonly type = ShapeType.STAR;
+
+  public position: Property = new Property(this, PropertyType.POSITION);
+
+  public innerRadius: Property = new Property(this, PropertyType.NUMBER);
+
+  public innerRoundness: Property = new Property(this, PropertyType.NUMBER);
+
+  public outerRadius: Property = new Property(this, PropertyType.NUMBER);
+
+  public outerRoundness: Property = new Property(this, PropertyType.NUMBER);
+
+  public rotation: Property = new Property(this, PropertyType.ROTATION);
+
+  public points: Property = new Property(this, PropertyType.NUMBER);
+
+  public starType: StarType = StarType.STAR;
+
+  /**
+   * Convert the Lottie JSON object to class instance.
+   *
+   * @param json    JSON object
+   * @returns       StarShape instance
+   */
+  public fromJSON(json: Record<string, any>): StarShape {
+    // Base shape
+    this.classNames = json.cl;
+    this.id = json.ln;
+    this.isHidden = json.hd;
+    this.matchName = json.mn;
+    this.name = json.nm;
+
+    // This shape
+    this.position.fromJSON(json.p);
+    this.innerRadius.fromJSON(json.ir);
+    this.innerRoundness.fromJSON(json.is);
+    this.outerRadius.fromJSON(json.or);
+    this.outerRoundness.fromJSON(json.os);
+    this.rotation.fromJSON(json.r);
+    this.points.fromJSON(json.pt);
+    this.starType = json.sy;
+
+    return this;
+  }
+
+  /**
+   * Convert the class instance to Lottie JSON object.
+   *
+   * Called by Javascript when serializing object with JSON.stringify()
+   *
+   * @returns       JSON object
+   */
+  public toJSON(): Record<string, any> {
+    return {
+      ty: this.type,
+
+      // Base shape
+      cl: this.classNames,
+      hd: this.isHidden,
+      ln: this.id,
+      mn: this.matchName,
+      nm: this.name,
+
+      // This shape
+      p: this.position,
+      ir: this.innerRadius,
+      is: this.innerRoundness,
+      or: this.outerRadius,
+      os: this.outerRoundness,
+      r: this.rotation,
+      pt: this.points,
+      sy: this.starType,
+    };
+  }
+}

--- a/src/shapes/trim-shape.ts
+++ b/src/shapes/trim-shape.ts
@@ -1,4 +1,5 @@
 import { BlendMode, PropertyType, ShapeType } from '../constants';
+import { TrimMode } from '../constants';
 import { Property } from '../properties';
 import { Shape } from './shape';
 
@@ -19,6 +20,8 @@ export class TrimShape extends Shape {
 
   public trimStart: Property = new Property(this, PropertyType.NUMBER);
 
+  public trimMultipleShapes: TrimMode = TrimMode.SIMULTANEOUSLY;
+
   /**
    * Convert the Lottie JSON object to class instance.
    *
@@ -38,6 +41,7 @@ export class TrimShape extends Shape {
     this.trimEnd.fromJSON(json.e);
     this.trimOffset.fromJSON(json.o);
     this.trimStart.fromJSON(json.s);
+    this.trimMultipleShapes = json.m in TrimMode ? json.m : TrimMode.INDIVIDUALLY;
 
     return this;
   }
@@ -65,6 +69,7 @@ export class TrimShape extends Shape {
       e: this.trimEnd,
       o: this.trimOffset,
       s: this.trimStart,
+      m: this.trimMultipleShapes,
     };
   }
 }

--- a/src/timeline/key-frame.ts
+++ b/src/timeline/key-frame.ts
@@ -8,6 +8,12 @@ export class KeyFrame {
   public frameOutTangent?: [number, number];
   public valueInTangent?: [number, number];
   public valueOutTangent?: [number, number];
+  public hold = false;
+
+  public constructor(frame = 0, value: number | number[] = 0) {
+    this.frame = frame;
+    this.value = value;
+  }
 
   /**
    * Convert the Lottie JSON object to class instance.
@@ -32,6 +38,8 @@ export class KeyFrame {
       ? ['x' in json.to ? json.to.x : json.to[0], 'y' in json.to ? json.to.y : json.to[1]]
       : undefined;
 
+    this.hold = 'h' in json && json.h;
+
     return this;
   }
 
@@ -49,7 +57,9 @@ export class KeyFrame {
       s: this.value,
     };
 
-    if (this.frameInTangent && this.frameOutTangent) {
+    if (this.hold) {
+      json.h = 1;
+    } else if (this.frameInTangent && this.frameOutTangent) {
       json.i = { x: this.frameInTangent[0], y: this.frameInTangent[1] };
       json.o = { x: this.frameOutTangent[0], y: this.frameOutTangent[1] };
     }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`yarn build`) was run locally and any changes were pushed
- [x] Lint (`yarn lint`) has passed locally and any fixes were made for failures

## Pull request type

Please check the type of change your PR introduces:

- Bug Fix
- Feature

## What is the new behavior?

Adds a few different shape classes and other small features I needed to export lottie correctly

New shapes:
- GradientStroke
- Repeater
- Star
- Rounded Corners

Changes:
- Optional argument for initializing properties with a value
- Added a gradient property class 
- Fixed some gradient type enum values
- Added trim path multiple shapes enum
- Added support for hold frames

## Does this introduce a breaking change?

- [x] Yes

Mostly related to gradients, some gradient type enum values have been changed to match how they are rendered by lottie.
`GradientFillShape.gradientColors` uses the new gradient property which matches the structure of the lottie json.
The gradient property also has method to handle the gradient values in a more user friendly way than raw lottie gradient color arrays, but they are still stored as arrays.
