### PR TITLE
Fix loading gradients from JSON

### DIFF
--- a/src/animation/animation.test.ts
+++ b/src/animation/animation.test.ts
@@ -1,6 +1,7 @@
 import fetch from 'cross-fetch';
 
 import { useRegistry } from '../utils/use-registry';
+import { Color } from '../values';
 import { Animation } from './animation';
 
 function sortObjectKeys(value: any): Record<string, any> {
@@ -42,11 +43,13 @@ test('Load an animation', async () => {
 test('Get unique colors', async () => {
   const anim = await Animation.fromURL('https://assets2.lottiefiles.com/private_files/lf30_k2c7t4.json');
 
-  expect(anim.colors).toEqual([
-    [255, 255, 255, 1],
-    [254, 184, 77, 1],
-    [205, 16, 16, 1],
-  ]);
+  const colors = [
+    Color.fromJSON([1, 1, 1, 1]),
+    Color.fromJSON([0.997385600969, 0.721629961799, 0.301171276616, 1]),
+    Color.fromJSON([0.803921987496, 0.062001998752, 0.062001998752, 1]),
+  ];
+
+  expect(anim.colors).toEqual(colors);
 });
 
 test('Get text layer', async () => {

--- a/src/constants/property-type.ts
+++ b/src/constants/property-type.ts
@@ -19,4 +19,5 @@ export enum PropertyType {
   NUMBER = 'nu',
   COLOR = 'cl',
   ORIENTATION = 'or',
+  GRADIENT = 'gr',
 }

--- a/src/properties/gradient.ts
+++ b/src/properties/gradient.ts
@@ -92,7 +92,7 @@ class GradientColorsProperty extends Property {
 }
 
 export class Gradient {
-  public gradientColors: GradientColorsProperty = new GradientColorsProperty(this, PropertyType.COLOR);
+  public gradientColors: GradientColorsProperty = new GradientColorsProperty(this, PropertyType.GRADIENT);
 
   public get colorCount(): number {
     return this.gradientColors.colorCount;

--- a/src/shapes/gradient-fill-shape.ts
+++ b/src/shapes/gradient-fill-shape.ts
@@ -52,7 +52,7 @@ export class GradientFillShape extends Shape {
     this.startPoint.fromJSON(json.s);
     this.fillRule = json.r;
 
-    if (this.gradientType === GradientFillType.LINEAR) {
+    if (this.gradientType === GradientFillType.RADIAL) {
       this.highlightAngle.fromJSON(json.a);
       this.highlightLength.fromJSON(json.h);
     }

--- a/src/shapes/gradient-stroke-shape.ts
+++ b/src/shapes/gradient-stroke-shape.ts
@@ -74,7 +74,7 @@ export class GradientStrokeShape extends Shape {
     this.gradientType = json.t;
     this.startPoint.fromJSON(json.s);
 
-    if (this.gradientType === GradientFillType.LINEAR) {
+    if (this.gradientType === GradientFillType.RADIAL) {
       this.highlightAngle.fromJSON(json.a);
       this.highlightLength.fromJSON(json.h);
     }

--- a/src/shapes/index.ts
+++ b/src/shapes/index.ts
@@ -11,3 +11,4 @@ export * from './gradient-stroke-shape';
 export * from './repeater-shape';
 export * from './star-shape';
 export * from './rounded-corners-shape';
+export * from './merge-shape';


### PR DESCRIPTION

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`yarn build`) was run locally and any changes were pushed
- [x] Lint (`yarn lint`) has passed locally and any fixes were made for failures

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Gradient fills / strokes weren't being loaded correctly

## What is the new behavior?

- loads .a / .h only if the gradient is radial (rather than linear)
- doesn't load the colors a single color

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
