### PR TITLE
Fixed path shape parsing

### DIFF
--- a/src/shapes/path-shape.test.ts
+++ b/src/shapes/path-shape.test.ts
@@ -1,0 +1,37 @@
+import { PathShape } from './path-shape';
+
+describe('Path Shape', () => {
+  it('fromJSON() is equal to toJSON()?', () => {
+    const pathDef = {
+      c: true,
+      v: [
+        [53, 325],
+        [429, 147],
+      ],
+      i: [
+        [0, 0],
+        [-147, 186],
+      ],
+      o: [
+        [89, -189],
+        [40, 189],
+      ],
+    };
+    const shapeDef = {
+      nm: 'Path',
+      mn: 'Path',
+      hd: false,
+      ty: 'sh',
+      ks: {
+        a: 0,
+        k: pathDef,
+      },
+    };
+
+    const shape = new PathShape(null);
+    shape.fromJSON(shapeDef);
+
+    expect(shape.vertices.values[0].value).toStrictEqual(pathDef);
+    expect(JSON.parse(JSON.stringify(shape))).toEqual(shapeDef);
+  });
+});

--- a/src/shapes/path-shape.ts
+++ b/src/shapes/path-shape.ts
@@ -33,7 +33,7 @@ export class PathShape extends Shape {
 
     // This shape
     this.direction = json.d;
-    this.vertices = json.ks;
+    this.vertices.fromJSON(json.ks);
 
     return this;
   }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Build (`yarn build`) was run locally and any changes were pushed
- [x] Lint (`yarn lint`) has passed locally and any fixes were made for failures

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix

## What is the current behavior?

Vertices property of path shape is replaced by json object. It will throw an error when trying to access pathShape.vertices.values.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

Vertices property of path shape correctly parses json.

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Does this introduce a breaking change?

- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
