### PR TITLE
fix: clear registry on Animation instatiation

### DIFF
--- a/src/animation/animation.test.ts
+++ b/src/animation/animation.test.ts
@@ -57,3 +57,11 @@ test('Get text layer', async () => {
   expect(Object.keys(anim.textLayers)).toContain('0.text_two');
   expect(Object.keys(anim.textLayers)).toContain('1.text_one');
 });
+
+test('Must have expected number of colors', async () => {
+  const color1 = await Animation.fromURL('https://assets9.lottiefiles.com/packages/lf20_ecmsvaa7.json');
+  const color2 = await Animation.fromURL('https://assets3.lottiefiles.com/packages/lf20_pmxrarjp.json');
+
+  expect(color1.colors.length).toEqual(1);
+  expect(color2.colors.length).toEqual(1);
+});

--- a/src/animation/animation.ts
+++ b/src/animation/animation.ts
@@ -37,6 +37,10 @@ export class Animation {
   public fonts: FontList = new FontList();
   public characters: Character[] = [];
 
+  public constructor() {
+    useRegistry().clear();
+  }
+
   /**
    * Create a class instance from the URL to the Lottie JSON.
    *


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x ] Build (`yarn build`) was run locally and any changes were pushed
- [x] Lint (`yarn lint`) has passed locally and any fixes were made for failures

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Registry is not cleared when new animations instantiated, this causes metadata such as color enumeration to include
colors from previously instantiated animations as well.

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->
Clears the registry on instantiation.

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
