### PR TITLE
Fix: Optional text fill color

### DIFF
--- a/src/values/text-document.ts
+++ b/src/values/text-document.ts
@@ -1,10 +1,10 @@
 import { TextCaps, TextJustify } from '../constants';
-import { Color, ColorRgb } from './color';
+import { Color } from './color';
 import { Value } from './value';
 
 export class TextDocument implements Value {
   public fontFamily = '';
-  public fontColor: Color = new ColorRgb(0, 0, 0);
+  public fontColor?: Color;
   public fontSize = 0;
   public text = '';
 


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`yarn build`) was run locally and any changes were pushed
- [x] Lint (`yarn lint`) has passed locally and any fixes were made for failures

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

A default black color is always applied to the text. It is therefore impossible to display a text with a stroke and a transparent background.

![image](https://user-images.githubusercontent.com/190189/165960670-f6228550-4e4e-4148-9933-0f1fe3f57944.png)

## What is the new behavior?

Text color is now optional.

Result:

![image](https://user-images.githubusercontent.com/190189/165960805-cd4173d9-7c52-406e-8792-dabe540951ad.png)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

[Here the link](https://lottiefiles.com/share/9w7jffle) of a generated json using the patched lottie-js version.