### PR TITLE
Fix: make layer width and height optional

### DIFF
--- a/src/layers/layer.ts
+++ b/src/layers/layer.ts
@@ -15,7 +15,7 @@ export abstract class Layer {
   public autoOrient = false;
   public blendMode: BlendMode = BlendMode.NORMAL;
   public classNames: string[] = [];
-  public height = 0;
+  public height?: number;
   public id = '';
   public index?: number;
   public inPoint = 0;
@@ -24,7 +24,7 @@ export abstract class Layer {
   public outPoint = 0;
   public startTime = 0;
   public timeStretch = 1;
-  public width = 0;
+  public width?: number;
   public matteMode?: MatteMode;
   public matteTarget?: number;
   public isHidden?: boolean;

--- a/src/layers/precomposition-layer.ts
+++ b/src/layers/precomposition-layer.ts
@@ -7,9 +7,13 @@ import { Layer } from './layer';
 export class PrecompositionLayer extends Layer {
   public readonly type = LayerType.PRECOMPOSITION;
 
+  public height = 512;
+
   public refId?: string;
 
   public timeRemap: any;
+
+  public width = 512;
 
   /**
    * Convert the Lottie JSON object to class instance.


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`yarn build`) was run locally and any changes were pushed
- [x] Lint (`yarn lint`) has passed locally and any fixes were made for failures

Please check the type of change your PR introduces:

- [x] Bugfix

## What is the current behavior?

When creating any kind of layer, the width and height properties are set to 0 by default. They are mandatory.

According to the specs, width and height are mandatory [only for precomposition layers](https://lottiefiles.github.io/lottie-docs/schema/#/$defs/layers/precomposition-layer) and in this case, width/height default to 512px.

Some players, like Adobe XD, do not display correctly shape layers when width and heigh are set.

## What is the new behavior?

When creating a layer, which is not a precomposition, the width and height properties are not defined by default

## Does this introduce a breaking change?

- [ ] Yes
- [x] No