### PR TITLE
fix: accept nullish ti/to

### DIFF
--- a/.changeset/rude-parents-repair.md
+++ b/.changeset/rude-parents-repair.md
@@ -1,0 +1,5 @@
+---
+'@lottiefiles/lottie-js': patch
+---
+
+Fix crash when parsing `null` value tangents

--- a/src/timeline/key-frame.ts
+++ b/src/timeline/key-frame.ts
@@ -36,13 +36,13 @@ export class KeyFrame {
     this.frameOutTangent = hasFrameTangents ? [json.o.x, json.o.y] : undefined;
 
     if (hasValueTangents) {
-      if ('x' in json.ti && 'y' in json.ti) {
+      if (json.ti && 'x' in json.ti && 'y' in json.ti) {
         this.valueInTangent = [json.ti.x, json.ti.y];
       } else {
         this.valueInTangent = json.ti;
       }
 
-      if ('x' in json.to && 'y' in json.to) {
+      if (json.to && 'x' in json.to && 'y' in json.to) {
         this.valueOutTangent = [json.to.x, json.to.y];
       } else {
         this.valueOutTangent = json.to;


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`yarn build`) was run locally and any changes were pushed
- [x] Lint (`yarn lint`) has passed locally and any fixes were made for failures

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Crash when a lottie that has a KeyFrame with `null` value tangents are parsed.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Accept KeyFrames with `null` value tangents. This change affects the accepted inputs only. The output remains unchanged: `KeyFrame::toJSON` discards falsey value tangents.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
