### PR TITLE
Fix: default to undefined generator for parsed lotties

### DIFF
--- a/.changeset/bright-eggs-marry.md
+++ b/.changeset/bright-eggs-marry.md
@@ -1,0 +1,5 @@
+---
+'@lottiefiles/lottie-js': patch
+---
+
+**metadata**: set empty array for files with no keywords

--- a/.changeset/poor-lizards-dance.md
+++ b/.changeset/poor-lizards-dance.md
@@ -1,0 +1,5 @@
+---
+'@lottiefiles/lottie-js': patch
+---
+
+**metadata**: do not use the default generator when a file does not have metadata

--- a/src/animation/animation.ts
+++ b/src/animation/animation.ts
@@ -354,6 +354,9 @@ export class Animation {
 
     if ('meta' in json) {
       this.meta.fromJSON(json.meta);
+    } else {
+      this.meta.fromJSON({});
+      this.meta.generator = undefined;
     }
 
     if ('fonts' in json) {

--- a/src/animation/meta.ts
+++ b/src/animation/meta.ts
@@ -51,7 +51,7 @@ export class Meta {
    */
   public fromJSON(json: Record<string, any>): Meta {
     this.author = json.a;
-    this.keywords = 'k' in json ? json.k.split(',').map((w: string) => w.trim()) : [json.k];
+    this.keywords = 'k' in json ? json.k.split(',').map((w: string) => w.trim()) : [];
     this.generator = json.g;
     this.description = json.d;
     this.themeColor = json.tc;


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

The library currently sets itself as the default generator, even when it is passed a Lottie that does not have a generator. Override behavior of `Animation.fromJSON` to set metadata fields as undefined when a Lottie without metadata is passed. 

The keywords is also changed to be an empty array, instead of array of length 1 in this case.

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`yarn build`) was run locally and any changes were pushed
- [ ] Lint (`yarn lint`) has passed locally and any fixes were made for failures

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- `Animation.meta.generator` is set to `@lottiefiles/lottie-js ${version}` when initialized from a JSON object without metadata
- `Animation.meta.keywords` is set to an array of length one, with an `undefined` element, when initialized from a JSON object without metadata

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- `Animation.meta.generator` will be undefined when initialized from a JSON object without metadata.
- `Animation.meta.keywords` will be an empty array when initialized from a JSON object without metadata.

## Does this introduce a breaking change?

- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
